### PR TITLE
Fix message deduplication when double puppeting is enabled + memory leak

### DIFF
--- a/BLMautrixTask.h
+++ b/BLMautrixTask.h
@@ -16,7 +16,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (strong, nonatomic) NSString * outputString;
 @property (strong, nonatomic) NSPipe * writePipe;
 @property (strong, nonatomic) NSMutableArray * sessionSentGUIDs;
-@property (strong, nonatomic) IMMessage * mostRecentMessage;
+@property (strong, nonatomic) NSString * mostRecentMessageGUID;
 @property (strong, nonatomic) CPDistributedMessagingCenter * messageCenter;
 +(id)sharedTask;
 -(id)initAndLaunch;


### PR DESCRIPTION
- Comparing IMMessage with each other won't work, we need to compare the GUID
- Fix memory leak that would grow the list of GUID to compare indefinitely and limit the array to 10 GUIDs
- Improve prefixes for logging to enable easier `grep`ing